### PR TITLE
Fix socketio error in reverse proxy setup

### DIFF
--- a/build/common/nginx-default.conf.template
+++ b/build/common/nginx-default.conf.template
@@ -30,7 +30,7 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header X-Frappe-Site-Name $host;
-        proxy_set_header Origin $scheme://$http_host;
+        proxy_set_header Origin $http_referer;
         proxy_set_header Host $http_host;
 
         proxy_pass http://socketio-server;


### PR DESCRIPTION
In order to fix #231 I was able get rid of the error message in the log file with setting the origin to $http_referer. 

I did this because the socketio script extracts the URL from the origin header as you can see here:
https://github.com/frappe/frappe/blob/8e867688481d9a1df8050358545660b657dd49dc/socketio.js#L296

In my case, I was able to fix my issue but I don't have a clue, if something else breaks after this change.